### PR TITLE
Implements ODOH Client API from the command line interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,23 +6,10 @@ This is a command line interface as a client for performing oblivious dns-over-h
 ### Current Support:
 
 - [x] DoH Query : `odoh-client doh --domain www.cloudflare.com. --dnsType AAAA`
-- [ ] oDoH Query: `odoh-client odoh --domain www.cloudflare.com. --dnsType AAAA --keyID 0123`
+- [x] oDoH Query: `odoh-client odoh --domain www.cloudflare.com. --dnsType AAAA --key 01234567890123456789012345678912 --target 1.1.1.1`
 
-# Testing
+The current implementation for oDoH uses a dummy Public Key stub on the target server which provides the public key to 
+the client. In the ideal implementation, this will be obtained after performing DNSSEC validation + HTTPSSVC.
 
-Locally, using curl:
-
-~~~
-$ curl -v "http://localhost:8080/dns-query?dns=YXBwbGUuY29t"
-$ curl -v -H "Content-Type:application/dns-message" -X POST -d "YXBwbGUuY29t" "http://localhost:8080/dns-query"
-$ curl -v -H "Content-Type:application/dns-message" -X POST --data-binary "@/Volumes/src/oss/go/src/github.com/chris-wood/odoh-client/out" "http://localhost:8080/dns-query"
-~~~
-
-("YXBwbGUuY29t" is the base64url-encoding of "apple.com".)
-
-After deployment, using a version of curl with DoH [https://curl.haxx.se/download.html#MacOSX]:
-
-~~~
-$ /usr/local/opt/curl/bin/curl -v --doh-url https://odoh-target-dot-odoh-254517.appspot.com/dns-query https://apple.com
-$ /usr/local/opt/curl/bin/curl -v -H "Content-Type:application/oblivious-dns-message" -X POST "https://odoh-proxy-dot-odoh-254517.appspot.com/dns-query/proxy"
-~~~
+The explicit query for the public key of a target server without validation can be obtained by performing 
+`odoh-client get-publickey --ip 1.1.1.1[:port]`

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -28,14 +28,33 @@ var Commands = []cli.Command{
 			cli.StringFlag{
 				Name:  "domain, d",
 				Value: "www.cloudflare.com.",
+				Usage: "Domain name which needs to be resolved. Use trailing period (.).",
 			},
 			cli.StringFlag{
 				Name:  "dnstype, t",
 				Value: "AAAA",
+				Usage: "Type of DNS Question. Currently supports A, AAAA, CAA, CNAME",
 			},
 			cli.StringFlag{
-				Name: "keyID, k",
-				Value: "0000",
+				Name: "target",
+				Value: "localhost:8080",
+				Usage: "Hostname:Port format declaration of the target resolver IP address",
+			},
+			cli.StringFlag{
+				Name: "key, k",
+				Value: "00000000000000000000000000000000",  // 16 bytes or 32 byte hex string
+				Usage: "Hex Encoded String containing the Symmetric Key which is used to return an Encrypted Response",
+			},
+		},
+	},
+	{
+		Name: "get-publickey",
+		Usage: "Retrieves the public key of the target resolver",
+		Action: getTargetPublicKey,
+		Flags: []cli.Flag {
+			cli.StringFlag{
+				Name: "ip",
+				Value: "localhost:8080",
 			},
 		},
 	},

--- a/commands/request.go
+++ b/commands/request.go
@@ -3,16 +3,23 @@ package commands
 import (
 	"bytes"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
+	"github.com/bifurcation/hpke"
 	"github.com/chris-wood/dns"
 	"github.com/chris-wood/odoh"
+	"github.com/kelindar/binary"
 	"github.com/urfave/cli"
 	"io/ioutil"
 	"log"
 	"net/http"
 )
 
-func createPlainQueryRequest(serializedDnsQueryString []byte) (response *dns.Msg, err error) {
+const (
+	OBLIVIOUS_DOH = "application/oblivious-dns-message"
+)
+
+func createPlainQueryResponse(serializedDnsQueryString []byte) (response *dns.Msg, err error) {
 	client := http.Client{}
 	req, err := http.NewRequest(http.MethodGet, "http://localhost:8080/dns-query", nil)
 	if err != nil {
@@ -39,7 +46,7 @@ func createPlainQueryRequest(serializedDnsQueryString []byte) (response *dns.Msg
 	return dnsBytes, nil
 }
 
-func createOdohQueryRequest(serializedOdohDnsQueryString []byte) (response *odoh.ObliviousDNSMessage, err error) {
+func createOdohQueryResponse(serializedOdohDnsQueryString []byte) (response *odoh.ObliviousDNSMessage, err error) {
 	client := http.Client{}
 	req, err := http.NewRequest(http.MethodGet, "http://localhost:8080/dns-query",
 		bytes.NewBuffer(serializedOdohDnsQueryString))
@@ -56,12 +63,49 @@ func createOdohQueryRequest(serializedOdohDnsQueryString []byte) (response *odoh
 		log.Fatalln(err)
 	}
 
+	responseHeader := resp.Header.Get("Content-Type")
+	if responseHeader != OBLIVIOUS_DOH {
+		log.Fatalf("[WARN] The returned response does not have the %v Content-Type\n", OBLIVIOUS_DOH)
+		// TODO: Design decision, break here.
+	}
+
 	bodyBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		log.Fatalln(err)
 	}
-	fmt.Printf("ODNS Bytes : %v\n", bodyBytes)
-	return &odoh.ObliviousDNSMessage{}, nil
+
+	hexBodyBytes := hex.EncodeToString(bodyBytes)
+	log.Printf("[ODOH] Hex Encrypted Response : %v\n", hexBodyBytes)
+
+	odohQueryResponse, err := odoh.UnmarshalDNSMessage(bodyBytes)
+
+	if err != nil {
+		log.Fatalln("Unable to Unmarshal the Encrypted ODOH Response")
+	}
+
+	return odohQueryResponse, nil
+}
+
+func retrievePublicKey(ip string) (response odoh.ObliviousDNSPublicKey, err error) {
+	req, err := http.NewRequest(http.MethodGet, "https://" + ip + "/pk", nil)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	client := http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var odohPublicKey odoh.ObliviousDNSPublicKey
+	err = binary.Unmarshal(bodyBytes, &odohPublicKey)
+
+	return odohPublicKey, err
 }
 
 
@@ -74,7 +118,12 @@ func plainDnsRequest(c *cli.Context) error {
 	fmt.Println("[DNS] Request : ", domainName, dnsTypeString)
 
 	serializedDnsQuestion := prepareDnsQuestion(domainName, dnsType)
-	response, _ := createPlainQueryRequest(serializedDnsQuestion)
+	response, err := createPlainQueryResponse(serializedDnsQuestion)
+
+	if err != nil {
+		log.Fatalf("Unable to obtain a valid response for the DNS Query. %v\n", err)
+	}
+
 	fmt.Println("[DNS] Response : \n", response)
 	return nil
 }
@@ -83,13 +132,86 @@ func obliviousDnsRequest(c *cli.Context) error {
 	domainName := c.String("domain")
 	dnsTypeString := c.String("dnstype")
 	key := c.String("key")
+	targetIP := c.String("target")
+
+	odohPublicKeyBytes, err := retrievePublicKey(targetIP)
+
+	if err != nil {
+		fmt.Println("Failed to obtain the public key of the target resolver.", err)
+		return nil
+	}
 
 	dnsType := dnsQueryStringToType(dnsTypeString)
 
 	fmt.Println("[ODNS] Request : ", domainName, dnsTypeString, key)
 
-	serializedODnsQuestion := prepareOdohQuestion(domainName, dnsType, []byte(key))
-	response, _ := createOdohQueryRequest(serializedODnsQuestion)
-	fmt.Println("[ODNS] Response : \n", response)
+	serializedODoHQueryMessage, err := prepareOdohQuestion(domainName, dnsType, []byte(key), odohPublicKeyBytes)
+
+	if err != nil {
+		log.Fatalln("Unable to Create the ODoH Query with the DNS Question")
+	}
+
+	odohMessage, err := createOdohQueryResponse(serializedODoHQueryMessage)
+	if err != nil {
+		log.Fatalln("Unable to Obtain an Encrypted Response from the Target Resolver")
+	}
+
+	dnsResponse, err := ValidateEncryptedResponse(odohMessage, []byte(key))
+	fmt.Println("[ODOH] Response : \n", dnsResponse)
+	return nil
+}
+
+func ValidateEncryptedResponse(message *odoh.ObliviousDNSMessage, key []byte) (response *dns.Msg, err error) {
+	odohResponse := odoh.ObliviousDNSResponse{ResponseKey: key}
+
+	responseMessageType := message.MessageType
+	if responseMessageType != odoh.ResponseType {
+		log.Fatalln("[ERROR] The data obtained from the server is not of the response type")
+	}
+
+	encryptedResponse := message.EncryptedMessage
+
+	kemID := hpke.DHKEM_X25519
+	kdfID := hpke.KDF_HKDF_SHA256
+	aeadID := hpke.AEAD_AESGCM128
+
+	suite, err := hpke.AssembleCipherSuite(kemID, kdfID, aeadID)
+
+	if err != nil {
+		log.Fatalln("Unable to initialize HPKE Cipher Suite", err)
+	}
+
+	// The following lines are hardcoded on the server side for `aad`
+	responseKeyId := []byte{0x00, 0x00}
+	aad := append([]byte{0x02}, responseKeyId...) // message_type = 0x02, with an empty keyID
+
+	decryptedResponse, err := odohResponse.DecryptResponse(suite, aad, encryptedResponse)
+
+	if err != nil {
+		log.Fatalln("Unable to decrypt the obtained response using the symmetric key sent.")
+	}
+
+	log.Printf("[ODOH] [Decrypted Response] : %v\n", decryptedResponse)
+
+	dnsBytes, err := parseDnsResponse(decryptedResponse)
+	if err != nil {
+		log.Fatalln("Unable to parse DNS bytes after decryption of the message from target server.")
+		return nil, err
+	}
+
+	return dnsBytes, err
+}
+
+func getTargetPublicKey(c *cli.Context) error {
+	targetIP := c.String("ip")
+	/*
+	Ideally, this procedure will be replaced by a DNSSEC validation step followed by the retrieval of the PublicKey
+	from the SVCB or HTTPSSVC records of the target resolver by the client. For now, we bypass this procedure and
+	implement a procedure to retrieve the ObliviousDNSPublicKey which is used for encryption.
+	 */
+	fmt.Printf("Retrieving the Public Key from [%v]\n", targetIP)
+
+	odohPublicKeyBytes, _ := retrievePublicKey(targetIP)
+	fmt.Printf("[PK] Expectation : %v", odohPublicKeyBytes)
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,10 @@ module github.com/chris-wood/odoh-client
 go 1.14
 
 require (
+	github.com/bifurcation/hpke v0.0.0-20200603153819-0a6c8374cd9a
 	github.com/chris-wood/dns v0.0.0-20161202223856-f4d2b086946a
 	github.com/chris-wood/odoh v0.0.0-20200619224544-8cfb1f9f3228
+	github.com/kelindar/binary v1.0.9
 	github.com/miekg/dns v1.1.29 // indirect
 	github.com/urfave/cli v1.22.4
 )

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,9 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSY
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/kelindar/binary v1.0.9 h1:Rngq8Kd8BTdqJlmH6fvIlgKypMLcJGykynsyigjbMG8=
+github.com/kelindar/binary v1.0.9/go.mod h1:4zDwr5pQvY3i4xrRd1kC7pcuWvSU/Jbh/v2D0tZUPfE=
 github.com/miekg/dns v1.1.29 h1:xHBEhR+t5RzcFJjBLJlax2daXOrTYtr9z4WdKEfWFzg=
 github.com/miekg/dns v1.1.29/go.mod h1:KNUDUusw/aVsxyTYZM1oqvCicbwhgbNgztCETuNZ7xM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -22,6 +25,7 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/urfave/cli v1.22.4 h1:u7tSpNPPswAFymm8IehJhy4uJMlUuU/GmqSkvJ1InXA=


### PR DESCRIPTION
- Obtains the public key from the stub of the odoh resolver
- Uses the public key and a symmetric key chosen on demand to execute odoh
- Implements the corresponding encryption, decryption and validation methods

Depends on: https://github.com/chris-wood/odoh/pull/3

Signed-off-by: Sudheesh Singanamalla <sudheesh@cloudflare.com>