### PR TITLE
ODOH Client now forwards ODOH Requests via proxy and obtains the response

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,14 @@ This is a command line interface as a client for performing oblivious dns-over-h
 
 - [x] DoH Query : `odoh-client doh --domain www.cloudflare.com. --dnsType AAAA`
 - [x] oDoH Query: `odoh-client odoh --domain www.cloudflare.com. --dnsType AAAA --key 01234567890123456789012345678912 --target 1.1.1.1`
+- [x] oDoH Query via Proxy: `odoh-client odoh --domain www.cloudflare.com --dnsType AAAA --key 01234567890123456789012345678912 --target 1.1.1.1 --use-proxy true --proxy sampleproxy.service.hosted.net[:port]`
 
 The current implementation for oDoH uses a dummy Public Key stub on the target server which provides the public key to 
 the client. In the ideal implementation, this will be obtained after performing DNSSEC validation + HTTPSSVC.
 
 The explicit query for the public key of a target server without validation can be obtained by performing 
 `odoh-client get-publickey --ip 1.1.1.1[:port]`
+
+For the `proxy` usage, the client treats the `target` as the hostname and port of the intended target to which the proxy
+needs to forward the ODOH message and obtain a response from. The client then uses the `key` to decrypt the obtained 
+response from the Oblivious Target.

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -38,12 +38,23 @@ var Commands = []cli.Command{
 			cli.StringFlag{
 				Name: "target",
 				Value: "localhost:8080",
-				Usage: "Hostname:Port format declaration of the target resolver IP address",
+				Usage: "Hostname:Port format declaration of the target resolver hostname",
 			},
 			cli.StringFlag{
 				Name: "key, k",
 				Value: "00000000000000000000000000000000",  // 16 bytes or 32 byte hex string
 				Usage: "Hex Encoded String containing the Symmetric Key which is used to return an Encrypted Response",
+			},
+			cli.BoolFlag{
+				Name:        "use-proxy, up",
+				Usage:       "Boolean True/False value to set with proxy",
+				Required:    false,
+				Hidden:      false,
+			},
+			cli.StringFlag{
+				Name: "proxy, p",
+				Value: "localhost:8080",
+				Usage: "Hostname:Port format declaration of the proxy hostname",
 			},
 		},
 	},


### PR DESCRIPTION
- Adds example command to be used for the ODOH Query with a proxy and target.
- Updates the usage of the CLI with --use-proxy <bool> and --proxy <host:port>

Signed-off-by: Sudheesh Singanamalla <sudheesh@cloudflare.com>